### PR TITLE
Changed solr version in build.xml from 4.9.1 to 4.10.4 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1121,11 +1121,11 @@
 
   <target name="get-third-party-solr-dep" depends="init" description="Download Solr third party dependencies.">
     <get dest="${lib.solr}" usetimestamp="true" skipexisting="true">
-      <url url="http://apache.spd.co.il/lucene/solr/4.9.1/solr-4.9.1.zip" />
+      <url url="http://apache.spd.co.il/lucene/solr/4.10.4/solr-4.10.4.zip" />
     </get>
-    <unzip src="${lib.solr}/solr-4.9.1.zip" dest="${lib.solr}">
+    <unzip src="${lib.solr}/solr-4.10.4.zip" dest="${lib.solr}">
       <patternset>
-        <include name="solr-4.9.1/example/"/>
+        <include name="solr-4.10.4/example/"/>
       </patternset>
     </unzip>
   </target>


### PR DESCRIPTION
Solr 4.9.1 is no longer available from http://apache.spd.co.il/lucene/solr. This causes ant get-third-party-solr-dep to fail. The latest version of solr available from http://apache.spd.co.il/lucene/solr is 4.10.4