### PR TITLE
Added a travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+jdk: oraclejdk8


### PR DESCRIPTION
A Travis file allows us to use the Apache's Travis account to do automatic testing on pull requests and pushes on the repo which is mirrored to github. Currently the file is only set for oracle Java 8 for limiting testing time but multiple versions of Java can be included. The testing runs ./gradlew assemble which packages the project and then tests it. This is **not** meant to replace the Jenkins config of creating distribution builds.

**Note**: to enable this infra would have to add our repo.