### PR TITLE
WAVE-439 - Changes source compatibility to Java1.8 and fixes weird is…

### DIFF
--- a/pst/build.gradle
+++ b/pst/build.gradle
@@ -28,8 +28,8 @@ apply plugin: 'com.google.protobuf'
 // Project Level Settings
 //=============================================================================
 version = 0.1
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 def title = 'Apache Wave PST Compiler'
 def vendor = 'The Apache Software Foundation'
 

--- a/wave/build.gradle
+++ b/wave/build.gradle
@@ -38,8 +38,8 @@ applicationDefaultJvmArgs = [
         "-Djava.util.logging.config.file=config/wiab-logging.conf",
         "-Djava.security.auth.login.config=config/jaas.config"
 ]
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 compileJava {
     options.incremental = true
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FetchProfilesServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FetchProfilesServlet.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.wave.api.FetchProfilesRequest;
 import com.google.wave.api.FetchProfilesResult;
@@ -183,7 +184,7 @@ public final class FetchProfilesServlet extends HttpServlet {
   /**
    * Writes the json with profile results to Response.
    */
-  private void printJson(MessageLite message, HttpServletResponse resp)
+  private <P extends Message> void printJson(P message, HttpServletResponse resp)
       throws IOException {
     if (message == null) {
       resp.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FetchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FetchServlet.java
@@ -21,6 +21,7 @@ package org.waveprotocol.box.server.rpc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 
 import org.waveprotocol.box.common.comms.WaveClientRpc.DocumentSnapshot;
@@ -103,7 +104,7 @@ public final class FetchServlet extends HttpServlet {
     renderSnapshot(waveref, user, response);
   }
 
-  private void serializeObjectToServlet(MessageLite message, HttpServletResponse dest)
+  private <P extends Message> void serializeObjectToServlet(P message, HttpServletResponse dest)
       throws IOException {
     if (message == null) {
       // Snapshot is null. It would be nice to 404 here, but we can't let

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/ProtoSerializer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/ProtoSerializer.java
@@ -178,12 +178,12 @@ public final class ProtoSerializer {
    * @throws SerializationException if there is no serializer for
    *         {@code protoClass}.
    */
-  private <P> ProtoImplSerializer<? extends P, ?> getSerializer(Class<P> protoClass)
+  private <P extends Message, D extends ProtoWrapper<P> & GsonSerializable> ProtoImplSerializer<P, D> getSerializer(Class<P> protoClass)
       throws SerializationException {
     @SuppressWarnings("unchecked")
     // use of serializers map is safe.
-    ProtoImplSerializer<? extends P, ?> serializer =
-        (ProtoImplSerializer<? extends P, ?>) byClass.get(protoClass);
+    ProtoImplSerializer<P, D> serializer =
+        (ProtoImplSerializer<P, D>) byClass.get(protoClass);
     if (serializer == null) {
       throw new SerializationException("Unknown proto class: " + protoClass.getName());
     }
@@ -214,7 +214,7 @@ public final class ProtoSerializer {
    * @throws SerializationException if the class of {@code message} has not been
    *         registered.
    */
-  public JsonElement toJson(MessageLite message) throws SerializationException {
+  public <P extends Message>JsonElement toJson(P message) throws SerializationException {
     return getSerializer(message.getClass()).toGson(message, null, gson);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/SearchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/SearchServlet.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.wave.api.SearchResult;
 import com.google.wave.api.SearchResult.Digest;
@@ -157,7 +158,7 @@ public class SearchServlet extends AbstractSearchServlet {
   /**
    * Writes the json with search results to Response.
    */
-  private void serializeObjectToServlet(MessageLite message, HttpServletResponse resp)
+  private <P extends Message> void serializeObjectToServlet(P message, HttpServletResponse resp)
       throws IOException {
     if (message == null) {
       resp.sendError(HttpServletResponse.SC_FORBIDDEN);

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWrapper.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWrapper.java
@@ -23,6 +23,7 @@ import org.waveprotocol.wave.client.doodad.attachment.ImageThumbnail;
 import org.waveprotocol.wave.client.editor.content.CMutableDocument;
 import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.content.ContentNode;
+import org.waveprotocol.wave.client.editor.content.ContentTextNode;
 import org.waveprotocol.wave.client.editor.content.misc.Caption;
 import org.waveprotocol.wave.media.model.Attachment;
 import org.waveprotocol.wave.model.document.util.DocHelper;
@@ -118,8 +119,8 @@ public class ImageThumbnailWrapper {
    *                 or null if this wrapper should produce a builder
    * @return resulting XML builder.
    */
-  public XmlStringBuilderDoc<? super ContentElement, ContentElement, ?>
-      appendInto(XmlStringBuilderDoc<? super ContentElement, ContentElement, ?> builder) {
+  public XmlStringBuilderDoc<ContentNode, ContentElement, ContentTextNode> appendInto
+    (XmlStringBuilderDoc<ContentNode, ContentElement, ContentTextNode> builder) {
     if (builder == null) {
       builder = XmlStringBuilderDoc.createEmpty(element.getMutableDoc());
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/selection/SelectionAnnotationHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/selection/SelectionAnnotationHandler.java
@@ -576,7 +576,7 @@ public class SelectionAnnotationHandler implements AnnotationMutationHandler, Pr
     final String profileAddress = profile.getAddress();
     sessions.each(new ProcV<SessionData>() {
       @Override
-      public void apply(String _, SessionData value) {
+      public void apply(String s, SessionData value) {
         if (value.address.equals(profileAddress) && !value.isStale()) {
           value.replaceName(profile);
         }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/LiveConversationViewRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/LiveConversationViewRenderer.java
@@ -302,7 +302,7 @@ public class LiveConversationViewRenderer
     wave.removeListener(this);
     conversationRenderers.each(new ProcV<Conversation, LiveConversationRenderer>() {
       @Override
-      public void apply(Conversation _, LiveConversationRenderer value) {
+      public void apply(Conversation c, LiveConversationRenderer value) {
         value.destroy();
       }
     });

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicMapTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicMapTest.java
@@ -204,9 +204,11 @@ public class DocumentBasedBasicMapTest extends TestCase {
    * @param values list of entries to include in the document state
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(ListBuilder<String, Integer> values) {
-    return substrate(BasicFactories.observableDocumentProvider().create("data",
-        Collections.<String, String>emptyMap()), values);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N>  ValueContext<N, E> substrate(ListBuilder<String, Integer> values) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("data",Collections.<String, String>emptyMap());
+    return substrate(doc, values);
   }
 
   /**
@@ -214,8 +216,8 @@ public class DocumentBasedBasicMapTest extends TestCase {
    *
    * @return a map-context view of the document state.
    */
-  private static <N, E extends N> ValueContext<N, E> substrate(
-      ObservableMutableDocument<N, E, ?> doc,
+  private static <N, E extends N, T extends N> ValueContext<N, E> substrate(
+      ObservableMutableDocument<N, E, T> doc,
       ListBuilder<String, Integer> values) {
     // Insert container element
     E container = doc.createChildElement(doc.getDocumentElement(), CONTAINER_TAG,

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicSetTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicSetTest.java
@@ -121,9 +121,11 @@ public class DocumentBasedBasicSetTest extends TestCase {
    * @param value list of entries to include in the document state
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(int ... value) {
-    return substrate(BasicFactories.observableDocumentProvider().create("data",
-        Collections.<String, String>emptyMap()), value);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N>  ValueContext<N, E> substrate(int ... value) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("data",Collections.<String, String>emptyMap());
+    return substrate(doc, value);
   }
 
   /**
@@ -131,8 +133,8 @@ public class DocumentBasedBasicSetTest extends TestCase {
    *
    * @return a map-context view of the document state.
    */
-  private static <N, E extends N> ValueContext<N, E> substrate(
-      ObservableMutableDocument<N, E, ?> doc,
+  private static <N, E extends N, T extends N> ValueContext<N, E> substrate(
+      ObservableMutableDocument<N, E, T> doc,
       int ... values) {
     // Insert container element
     E container = doc.createChildElement(doc.getDocumentElement(), CONTAINER_TAG,

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicValueTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedBasicValueTest.java
@@ -116,9 +116,11 @@ public class DocumentBasedBasicValueTest extends TestCase {
    * @param value list of entries to include in the document state
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(int value) {
-    return substrate(BasicFactories.observableDocumentProvider().create("data",
-        Collections.<String, String>emptyMap()), value);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N> ValueContext<N, E>substrate(int value) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("data",Collections.<String, String>emptyMap());
+    return substrate(doc, value);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedMonotonicMapTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedMonotonicMapTest.java
@@ -187,9 +187,11 @@ public class DocumentBasedMonotonicMapTest extends TestCase {
    * @param values list of entries to include in the document state
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(ListBuilder<String, Integer> values) {
-    return substrate(BasicFactories.observableDocumentProvider().create("data",
-        Collections.<String, String>emptyMap()), values);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N> ValueContext<N, E> substrate(ListBuilder<String, Integer> values) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("data",Collections.<String, String>emptyMap());
+    return substrate(doc, values);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedMonotonicValueTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedMonotonicValueTest.java
@@ -162,10 +162,12 @@ public class DocumentBasedMonotonicValueTest extends TestCase {
    * @param values list of entries to include in the document state
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(Integer ... values) {
-    return substrate(BasicFactories.observableDocumentProvider().create("data",
-        Collections.<String, String>emptyMap()),
-        values);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N> ValueContext<N, E>  substrate(Integer ... values) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("data",Collections.<String, String>emptyMap());
+
+    return substrate(doc, values);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedStructuredValueTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/adt/docbased/DocumentBasedStructuredValueTest.java
@@ -272,9 +272,11 @@ public class DocumentBasedStructuredValueTest extends TestCase {
    *
    * @return a map-context view of the document state
    */
-  private static ValueContext<?, ?> substrate(Map<Key, Integer> values) {
-    return substrate(BasicFactories.observableDocumentProvider().create("tagname",
-        Collections.<String, String>emptyMap()), values);
+  @SuppressWarnings("unchecked")
+  private static <N, E extends N> ValueContext<N, E> substrate(Map<Key, Integer> values) {
+    ObservableMutableDocument doc =
+      BasicFactories.observableDocumentProvider().create("tagname",Collections.<String, String>emptyMap());
+    return substrate(doc, values);
   }
 
   /**
@@ -282,8 +284,8 @@ public class DocumentBasedStructuredValueTest extends TestCase {
    *
    * @return a map-context view of the document state.
    */
-  private static <N, E extends N> ValueContext<N, E> substrate(
-      ObservableMutableDocument<N, E, ?> doc, Map<Key, Integer> values) {
+  private static <N, E extends N, T extends N> ValueContext<N, E> substrate(
+      ObservableMutableDocument<N, E, T> doc, Map<Key, Integer> values) {
     // Insert container element.
     E container = doc.createChildElement(doc.getDocumentElement(), CONTAINER_TAG,
         Collections.<String,String>emptyMap());


### PR DESCRIPTION
…sues with code that 1.8 was not backward compatible.

Some of the issues were resolved by updating to newer Java1.8 JDK version.